### PR TITLE
Update to React Native 0.30

### DIFF
--- a/Example/android/app/BUCK
+++ b/Example/android/app/BUCK
@@ -5,7 +5,7 @@ import re
 # - install Buck
 # - `npm start` - to start the packager
 # - `cd android`
-# - `keytool -genkey -v -keystore keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US`
+# - `keytool -genkey -v -keystore keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US"`
 # - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to Buck
 # - `buck install -r android/app` - compile, install and run application
 #

--- a/Example/ios/Example/AppDelegate.m
+++ b/Example/ios/Example/AppDelegate.m
@@ -18,7 +18,6 @@
 {
   NSURL *jsCodeLocation;
 
-  [[RCTBundleURLProvider sharedSettings] setDefaults];
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation

--- a/Example/package.json
+++ b/Example/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "react": "^15.2.1",
-    "react-native": "^0.29.2",
+    "react-native": "^0.30.0",
     "react-native-deltadna": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-deltadna",
   "description": "DeltaDNA integration for React Native",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/playabl/react-native-deltadna.git"
@@ -24,6 +24,6 @@
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
-    "react-native": "^0.29.0"
+    "react-native": ">=0.30.0"
   }
 }


### PR DESCRIPTION
This updates `react-native-deltadna` to React Native 0.30 and doesn't enforce the version number as strictly.