### PR TITLE
updated deltadna android sdk to 4.1.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.deltadna.android:deltadna-sdk:4.1.5'
+    compile 'com.deltadna.android:deltadna-sdk:4.1.6'
 }


### PR DESCRIPTION
We have released a patch update to the Android SDK with a small fix, so here is the version bump to get it in your project.