### PR TITLE
Remove createJSModules @override - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/playabl/deltadna/RNDeltaDNAPackage.java
+++ b/android/src/main/java/com/playabl/deltadna/RNDeltaDNAPackage.java
@@ -16,7 +16,7 @@ public class RNDeltaDNAPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNDeltaDNAModule(reactContext));
     }
 
-    @Override
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }

--- a/android/src/main/java/com/playabl/deltadna/RNDeltaDNAPackage.java
+++ b/android/src/main/java/com/playabl/deltadna/RNDeltaDNAPackage.java
@@ -16,7 +16,7 @@ public class RNDeltaDNAPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNDeltaDNAModule(reactContext));
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This is backwards compatible according to my tests.